### PR TITLE
There is no need in set PULSE_LATENCY_MSEC anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN dpkg --add-architecture i386 \
 
 # PulseAudio server.
 ENV PULSE_SERVER /run/pulse/native
-ENV PULSE_LATENCY_MSEC 30
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
With this option, pulseaudio-5.0 and skype-4.3.0.37 give me mic problems - too fast recording
